### PR TITLE
Fixes and tests for Firebird schema reading.

### DIFF
--- a/DatabaseSchemaReader.sln
+++ b/DatabaseSchemaReader.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DatabaseSchemaReader", "DatabaseSchemaReader\DatabaseSchemaReader.csproj", "{AA652F8E-0B96-484C-A146-C4183E4A0A25}"
 EndProject

--- a/DatabaseSchemaReader/Conversion/ForeignKeyColumnConverter.cs
+++ b/DatabaseSchemaReader/Conversion/ForeignKeyColumnConverter.cs
@@ -56,6 +56,7 @@ namespace DatabaseSchemaReader.Conversion
                 if (fk == null)
                 {
                     fk = CreateNewForeignKey(tableName, name);
+                    _foreignKeys.Add(fk);
                 }
 
                 string col = row[columnKey].ToString();

--- a/DatabaseSchemaReader/DatabaseSchemaReader.csproj
+++ b/DatabaseSchemaReader/DatabaseSchemaReader.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Filters\IFilter.cs" />
     <Compile Include="IDatabaseReader.cs" />
     <Compile Include="ProviderSchemaReaders\Db2ISeriesSchemaReader.cs" />
+    <Compile Include="ProviderSchemaReaders\FirebirdSqlSchemaReader.cs" />
     <Compile Include="ProviderSchemaReaders\OracleSequenceTrigger.cs" />
     <Compile Include="ProviderSchemaReaders\SchemaReaderFactory.cs" />
     <Compile Include="ProviderSchemaReaders\SqlAzureOrSqlServerSchemaReader.cs" />

--- a/DatabaseSchemaReader/ProviderSchemaReaders/FirebirdSqlSchemaReader.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/FirebirdSqlSchemaReader.cs
@@ -1,0 +1,17 @@
+﻿using System.Data;
+using System.Data.Common;
+
+namespace DatabaseSchemaReader.ProviderSchemaReaders
+{
+    class FirebirdSqlSchemaReader : SchemaExtendedReader
+    {
+        public FirebirdSqlSchemaReader(string connectionString, string providerName) : base(connectionString, providerName)
+        {
+        }
+
+        internal override string CheckConstraintsCollectionName
+        {
+            get { return "CheckConstraintsByTable"; }
+        }
+    }
+}

--- a/DatabaseSchemaReader/ProviderSchemaReaders/SchemaReaderFactory.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/SchemaReaderFactory.cs
@@ -63,6 +63,10 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders
                     {
                         schemaReader = new Db2ISeriesSchemaReader(connectionString, providerName);
                     }
+                    else if (providerName.Equals("FirebirdSql.Data.FirebirdClient", StringComparison.OrdinalIgnoreCase))
+                    {
+                        schemaReader = new FirebirdSqlSchemaReader(connectionString, providerName);
+                    }
 
                     break;
             }

--- a/DatabaseSchemaReader/SchemaExtendedReader.cs
+++ b/DatabaseSchemaReader/SchemaExtendedReader.cs
@@ -62,9 +62,8 @@ namespace DatabaseSchemaReader
                 var primaryKeys = PrimaryKeys(tableName, conn);
                 primaryKeys.TableName = PrimaryKeysCollectionName;
                 ds.Tables.Add(primaryKeys);
-                var foreignKeys = ForeignKeys(tableName, conn);
-                foreignKeys.TableName = ForeignKeyColumnsCollectionName;
-                ds.Tables.Add(foreignKeys);
+                ds.Tables.Add(ForeignKeys(tableName, conn));
+                ds.Tables.Add(ForeignKeyColumns(tableName, conn));
                 ds.Tables.Add(UniqueKeys(tableName, conn));
                 ds.Tables.Add(CheckConstraints(tableName, conn));
 

--- a/DatabaseSchemaReaderTest/App.config
+++ b/DatabaseSchemaReaderTest/App.config
@@ -15,7 +15,8 @@
       <!--<add name="SQL Anywhere UltraLite.NET 12 Data Provider" invariant="iAnywhere.Data.UltraLite" description=".Net Framework Data Provider for SQL Anywhere UltraLite.NET 12" type="iAnywhere.Data.UltraLite.ULFactory, iAnywhere.Data.UltraLite, Version=12.0.1.3152, Culture=neutral, PublicKeyToken=ff11483eb5a8c1a5" />-->
       <remove invariant="MySql.Data.MySqlClient" />
       <add name="MySQL Data Provider" invariant="MySql.Data.MySqlClient" description=".Net Framework Data Provider for MySQL" type="MySql.Data.MySqlClient.MySqlClientFactory, MySql.Data, Version=6.9.6.0, Culture=neutral, PublicKeyToken=c5687fc88969c44d" />
-    </DbProviderFactories>
+      <remove invariant="FirebirdSql.Data.FirebirdClient" />
+      <add name="FirebirdClient Data Provider" invariant="FirebirdSql.Data.FirebirdClient" description=".NET Framework Data Provider for Firebird" type="FirebirdSql.Data.FirebirdClient.FirebirdClientFactory, FirebirdSql.Data.FirebirdClient" /></DbProviderFactories>
   </system.data>
   <connectionStrings>
     <add name="CatalogContainer" connectionString="metadata=res://*/Utilities.EF.Catalog.csdl|res://*/Utilities.EF.Catalog.ssdl|res://*/Utilities.EF.Catalog.msl;provider=System.Data.SqlClient;provider connection string=&quot;data source=.\SQLEXPRESS;initial catalog=ProductCatalog;integrated security=True;multipleactiveresultsets=True;App=EntityFramework&quot;" providerName="System.Data.EntityClient" />

--- a/DatabaseSchemaReaderTest/DatabaseSchemaReaderTest.csproj
+++ b/DatabaseSchemaReaderTest/DatabaseSchemaReaderTest.csproj
@@ -38,6 +38,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FirebirdSql.Data.FirebirdClient, Version=4.6.4.0, Culture=neutral, PublicKeyToken=3750abcc3150b00c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\FirebirdSql.Data.FirebirdClient.4.6.4.0\lib\net40-client\FirebirdSql.Data.FirebirdClient.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Build" />
     <Reference Include="Microsoft.Build.Framework" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
@@ -238,7 +242,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Utilities\EF\CatalogV3.edmxv3" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/DatabaseSchemaReaderTest/IntegrationTests/Firebird.cs
+++ b/DatabaseSchemaReaderTest/IntegrationTests/Firebird.cs
@@ -1,4 +1,9 @@
-﻿using DatabaseSchemaReader;
+﻿using System;
+using System.IO;
+using System.Linq;
+using DatabaseSchemaReader;
+using DatabaseSchemaReader.DataSchema;
+using DatabaseSchemaReader.Utilities;
 #if !NUNIT
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #else
@@ -19,8 +24,13 @@ namespace DatabaseSchemaReaderTest.IntegrationTests
     [TestClass]
     public class Firebird
     {
-        [TestMethod, TestCategory("Firebird")]
-        public void FirebirdTest()
+        const string ProviderName = "FirebirdSql.Data.FirebirdClient";
+        const string Path = @"C:\Program Files\Firebird\Firebird_2_5\examples\empbuild\EMPLOYEE.FDB";
+        const string ConnectionString = "User=SYSDBA;Password=masterkey;Database=" + Path + ";Server=localhost; Connection lifetime=15;Pooling=true";
+        private DatabaseReader _dbReader;
+
+        [ClassInitialize]
+        public static void Config(TestContext context)
         {
             //  <system.data>
             //    <DbProviderFactories>
@@ -31,19 +41,50 @@ namespace DatabaseSchemaReaderTest.IntegrationTests
             //      />
             //    </DbProviderFactories>
             //  </system.data>
-            const string providername = "FirebirdSql.Data.FirebirdClient";
-            const string path = @"C:\Program Files\Firebird\Firebird_2_1\examples\empbuild\EMPLOYEE.FDB";
-            const string connectionString = "User=SYSDBA;Password=masterkey;Database=" + path + ";Server=localhost; Connection lifetime=15;Pooling=true";
 
-            ProviderChecker.Check(providername, connectionString);
+            ProviderChecker.Check(ProviderName, ConnectionString);
 
-            var dbReader = new DatabaseReader(connectionString, providername);
-            var schema = dbReader.ReadAll();
-            var employees = schema.FindTableByName("EMPLOYEE");
-            Assert.AreEqual(11, employees.Columns.Count);
-
-            var table = dbReader.Table("EMPLOYEE");
-            Assert.AreEqual(11, table.Columns.Count);
+            
         }
+        [TestInitialize]
+        public void Setup()
+        {
+            _dbReader = new DatabaseReader(ConnectionString, ProviderName);
+        }
+
+        [TestMethod, TestCategory("Firebird")]
+        public void ReadAll_OnFirebirdEmployeeDatabase_ShouldReturnTheCompleteSchema()
+        {
+            //Act
+            var schema = _dbReader.ReadAll();
+            //Assert
+            Assert.AreEqual(10, schema.Tables.Count, "The example database contains 10 tables.");
+            Assert.IsTrue(schema.Views.Any(s => s.Name == "PHONE_LIST"), "The example database contains PHONE_LIST view.");
+            Assert.IsTrue(schema.StoredProcedures.Any(s => s.Name == "ADD_EMP_PROJ"), "The example database contains ADD_EMP_PROJ stored procedure.");
+            Assert.IsTrue(schema.Functions.Any(f => f.Name == "RDB$GET_CONTEXT"), "The example database contains RDB$GET_CONTEXT function.");
+            Assert.IsTrue(schema.Sequences.Any(s => s.Name == "EMP_NO_GEN"), "The example database contains EMP_NO_GEN sequence.");
+            var employees = schema.FindTableByName("EMPLOYEE");
+            AssertEmployeeTableValid(employees);
+            Assert.AreEqual(1, employees.CheckConstraints.Count, "The employee table contains 1 constraint check.");
+            Assert.AreEqual(5, employees.ForeignKeyChildren.Count, "The employee table referenced by 5 tables.");
+        }
+
+        [TestMethod, TestCategory("Firebird")]
+        public void Table_OnEmployeeTable_ShouldReturnTheEmployeeTableInformation()
+        {
+            var employees = _dbReader.Table("EMPLOYEE");
+            AssertEmployeeTableValid(employees);
+        }
+
+        private static void AssertEmployeeTableValid(DatabaseTable employees)
+        {
+            Assert.AreEqual(11, employees.Columns.Count, "The employee table contains 11 columns.");
+            Assert.AreEqual(2, employees.ForeignKeys.Count, "The employee table contains 2 foreign keys.");
+            var integ28 = employees.ForeignKeys.FirstOrDefault(f => f.Name == "INTEG_28");
+            Assert.AreEqual(1, integ28.Columns.Count, "The INTEG_28 fk on employee table references with 1 key.");
+            var integ29 = employees.ForeignKeys.FirstOrDefault(f => f.Name == "INTEG_29");
+            Assert.AreEqual(3, integ29.Columns.Count, "The INTEG_28 fk on employee table references with 3 key.");
+        }
+
     }
 }

--- a/DatabaseSchemaReaderTest/packages.config
+++ b/DatabaseSchemaReaderTest/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FirebirdSql.Data.FirebirdClient" version="4.6.4.0" targetFramework="net40" />
   <package id="MySql.Data" version="6.9.6" targetFramework="net40" />
   <package id="Npgsql" version="2.2.5" targetFramework="net40" />
   <package id="System.Data.SQLite.Core" version="1.0.97.0" targetFramework="net40" />


### PR DESCRIPTION
Hy Martin!
I started using your work form a t4 generator. It's really great and easy to use but unfortunately it didn't worked on firebird. I made myself the fixes so I can use for my project. I share this fixes so you can migrate it if you like. These modifications:
Some additional tests for firebird and I changed 2.1 example db path to 2.5.
Foreign key columns was not added to the list in ForeignKeyColumnConverter.
Exception on check constraint reading. It seems fb uses CheckConstraintsByTable for store the check constraints.
in SchemaExtendedReader.Table ForeignKeys was added as ForeignKeyColumns. It made exception in the reading because it doesn't contain the column_name.