### PR TITLE
Adding support for connections with local pending transactions

### DIFF
--- a/CoreTest/TestSqlServer.cs
+++ b/CoreTest/TestSqlServer.cs
@@ -31,5 +31,25 @@ namespace DatabaseSchemaReaderTest
                 Assert.NotEmpty(tableList);
             }
         }
+
+        [Fact]
+        public void RunTableListWithTransaction()
+        {
+            using (var connection = new SqlConnection(Northwind))
+            {
+                connection.Open();
+                using (var txn = connection.BeginTransaction())
+                {
+                    var dr = new DatabaseSchemaReader.DatabaseReader(txn);
+                    var schema = dr.ReadAll();
+                    var tableList = dr.TableList();
+                    var tables = dr.AllTables();
+                    var views = dr.AllViews();
+                    Assert.NotEmpty(tableList);
+
+                    txn.Rollback();
+                }
+            }
+        }
     }
 }

--- a/DatabaseSchemaReader/DatabaseReader.cs
+++ b/DatabaseSchemaReader/DatabaseReader.cs
@@ -42,9 +42,9 @@ namespace DatabaseSchemaReader
         }
 
         /// <summary>
-        /// 
+        /// Initializes a new instance of the <see cref="DatabaseReader"/> class from a DbTransaction.
         /// </summary>
-        /// <param name="transaction"></param>
+        /// <param name="transaction">The transaction</param>
         public DatabaseReader(System.Data.Common.DbTransaction transaction) :
             this(transaction.Connection.GetType().Namespace, transaction.Connection.ConnectionString, new SchemaParameters(transaction))
         {   

--- a/DatabaseSchemaReader/DatabaseReader.cs
+++ b/DatabaseSchemaReader/DatabaseReader.cs
@@ -36,11 +36,25 @@ namespace DatabaseSchemaReader
         /// Initializes a new instance of the <see cref="DatabaseReader"/> class from a DbConnection.
         /// </summary>
         /// <param name="connection">The connection.</param>
-        public DatabaseReader(System.Data.Common.DbConnection connection)
+        public DatabaseReader(System.Data.Common.DbConnection connection) :
+            this(connection.GetType().Namespace, connection.ConnectionString, new SchemaParameters(connection))
         {
-            var name = connection.GetType().Namespace;
-            _db = new DatabaseSchema(connection.ConnectionString, name);
-            _schemaParameters = new SchemaParameters(connection) {DatabaseSchema = _db};
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="transaction"></param>
+        public DatabaseReader(System.Data.Common.DbTransaction transaction) :
+            this(transaction.Connection.GetType().Namespace, transaction.Connection.ConnectionString, new SchemaParameters(transaction))
+        {   
+        }
+
+        private DatabaseReader(string name, string connectionString, SchemaParameters schemaParameters)
+        {
+            _db = new DatabaseSchema(connectionString, name);
+            _schemaParameters = schemaParameters;
+            _schemaParameters.DatabaseSchema = _db;
             _readerAdapter = ReaderAdapterFactory.Create(_schemaParameters);
         }
 #endif

--- a/DatabaseSchemaReader/Properties/AssemblyInfo.cs
+++ b/DatabaseSchemaReader/Properties/AssemblyInfo.cs
@@ -32,7 +32,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.3.1.0")]
+[assembly: AssemblyFileVersion("2.3.1.0")]
 [assembly: CLSCompliant(true)]
 [assembly: InternalsVisibleTo("DatabaseSchemaReaderTest")]

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/FirebirdAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/FirebirdAdapter.cs
@@ -22,88 +22,88 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseView> Views(string viewName)
         {
             return new Views(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ViewColumns(string viewName)
         {
             return new ViewColumns(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> PrimaryKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.PrimaryKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> UniqueKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.UniqueKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.ForeignKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> CheckConstraints(string tableName)
         {
-            return new CheckConstraints(Owner, tableName).Execute(DbConnection);
+            return new CheckConstraints(Owner, tableName).Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTrigger> Triggers(string tableName)
         {
             return new Triggers(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseStoredProcedure> StoredProcedures(string name)
         {
             return new StoredProcedures(Owner)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseFunction> Functions(string name)
         {
             return new Functions(name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseArgument> ProcedureArguments(string name)
         {
             return new ProcedureArguments(Owner)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseSequence> Sequences(string name)
         {
-            return new Sequences().Execute(DbConnection);
+            return new Sequences().Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseUser> Users()
         {
-            return new Users().Execute(DbConnection);
+            return new Users().Execute(DbConnection, DbTransaction);
         }
     }
 }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/MySqlAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/MySqlAdapter.cs
@@ -18,89 +18,89 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ComputedColumns(string tableName)
         {
             return new ComputedColumns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseView> Views(string viewName)
         {
             return new Views(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ViewColumns(string viewName)
         {
             return new ViewColumns(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> PrimaryKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.PrimaryKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> UniqueKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.UniqueKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.ForeignKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> IdentityColumns(string tableName)
         {
             return new IdentityColumns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTrigger> Triggers(string tableName)
         {
             return new Triggers(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseStoredProcedure> StoredProcedures(string name)
         {
             return new StoredProcedures(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseFunction> Functions(string name)
         {
             return new Functions(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseArgument> ProcedureArguments(string name)
         {
             return new ProcedureArguments(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
         public override IList<DatabaseUser> Users()
         {
-            return new Users().Execute(DbConnection);
+            return new Users().Execute(DbConnection, DbTransaction);
         }
     }
 }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/OracleAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/OracleAdapter.cs
@@ -21,83 +21,83 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> PrimaryKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.PrimaryKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> UniqueKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.UniqueKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.ForeignKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ComputedColumns(string tableName)
         {
             return new ComputedColumns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> IdentityColumns(string tableName)
         {
             return new IdentityColumns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTrigger> Triggers(string tableName)
         {
             return new Triggers(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTable> ColumnDescriptions(string tableName)
         {
             return new ColumnDescriptions(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTable> TableDescriptions(string tableName)
         {
             return new TableDescriptions(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> CheckConstraints(string tableName)
         {
             return new CheckConstraints(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseView> Views(string viewName)
         {
             var views = new Views(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
             if (string.IsNullOrEmpty(viewName) || !views.Any())
             {
                 var mviews = new MaterializedViews(Owner, viewName)
-                    .Execute(DbConnection);
+                    .Execute(DbConnection, DbTransaction);
                 foreach (var mview in mviews)
                 {
                     views.Add(mview);
@@ -109,11 +109,11 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseColumn> ViewColumns(string viewName)
         {
             var columns = new ViewColumns(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
             if (string.IsNullOrEmpty(viewName) || !columns.Any())
             {
                 var mCols = new MaterializedViewColumns(Owner, viewName)
-                    .Execute(DbConnection);
+                    .Execute(DbConnection, DbTransaction);
                 foreach (var mcol in mCols)
                 {
                     columns.Add(mcol);
@@ -125,47 +125,47 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseIndex> ViewIndexes(string tableName)
         {
             return new ViewIndexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabasePackage> Packages(string name)
         {
             return new Packages(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseStoredProcedure> StoredProcedures(string name)
         {
             return new StoredProcedures(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseFunction> Functions(string name)
         {
             return new Functions(Owner)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseArgument> ProcedureArguments(string name)
         {
             return new ProcedureArguments(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<ProcedureSource> ProcedureSources(string name)
         {
             return new ProcedureSources(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseSequence> Sequences(string name)
         {
-            return new Sequences(Owner).Execute(DbConnection);
+            return new Sequences(Owner).Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseUser> Users()
         {
-            return new Users().Execute(DbConnection);
+            return new Users().Execute(DbConnection, DbTransaction);
         }
 
         public override void PostProcessing(DatabaseTable databaseTable)

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/PostgreSqlAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/PostgreSqlAdapter.cs
@@ -21,71 +21,71 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> PrimaryKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.PrimaryKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> UniqueKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.UniqueKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.ForeignKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTrigger> Triggers(string tableName)
         {
             return new Triggers(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> CheckConstraints(string tableName)
         {
             return new CheckConstraints(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTable> ColumnDescriptions(string tableName)
         {
             return new ColumnDescriptions(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTable> TableDescriptions(string tableName)
         {
             return new TableDescriptions(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseView> Views(string viewName)
         {
             var views = new Views(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
             if (string.IsNullOrEmpty(viewName) || !views.Any())
             {
                 var mviews = new MaterializedViews(Owner, viewName)
-                    .Execute(DbConnection);
+                    .Execute(DbConnection, DbTransaction);
                 foreach (var mview in mviews)
                 {
                     views.Add(mview);
@@ -97,17 +97,17 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseFunction> Functions(string name)
         {
             return new Functions(Owner)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseArgument> ProcedureArguments(string name)
         {
             return new ProcedureArguments(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
         public override IList<DatabaseUser> Users()
         {
-            return new Users().Execute(DbConnection);
+            return new Users().Execute(DbConnection, DbTransaction);
         }
 
         public override void PostProcessing(DatabaseTable databaseTable)

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/ReaderAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/ReaderAdapter.cs
@@ -43,6 +43,19 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
             }
         }
 
+        protected DbTransaction DbTransaction
+        {
+            get
+            {
+                if (_connectionAdapter == null)
+                {
+                    _connectionAdapter = new ConnectionAdapter(Parameters);
+                }
+                return _connectionAdapter.DbTransaction;
+
+            }
+        }
+
         public virtual string Owner
         {
             get { return Parameters.Owner; }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/SqLiteAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/SqLiteAdapter.cs
@@ -17,45 +17,45 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns( tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes( tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTrigger> Triggers(string tableName)
         {
             return new Triggers( tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
 
         public override IList<DatabaseView> Views(string viewName)
         {
             return new Views(viewName)
-               .Execute(DbConnection);
+               .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ViewColumns(string viewName)
         {
             return new ViewColumns(viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
     }
 }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/SqlServerAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/SqlServerAdapter.cs
@@ -79,137 +79,137 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseView> Views(string viewName)
         {
             return new Views(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<ProcedureSource> ViewSources(string viewName)
         {
             return new ViewSources(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ViewColumns(string viewName)
         {
             return new ViewColumns(Owner, viewName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> ViewIndexes(string tableName)
         {
             return new ViewIndexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> IdentityColumns(string tableName)
         {
             return new IdentityColumns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> CheckConstraints(string tableName)
         {
             return new CheckConstraints(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> PrimaryKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.PrimaryKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> UniqueKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.UniqueKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.ForeignKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> DefaultConstraints(string tableName)
         {
             return new DefaultConstraints(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> ComputedColumns(string tableName)
         {
             return new ComputedColumns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTrigger> Triggers(string tableName)
         {
             return new Triggers(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTable> ColumnDescriptions(string tableName)
         {
             return new ColumnDescriptions(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseTable> TableDescriptions(string tableName)
         {
             return new TableDescriptions(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseSequence> Sequences(string name)
         {
-            return new Sequences(Owner).Execute(DbConnection);
+            return new Sequences(Owner).Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseStoredProcedure> StoredProcedures(string name)
         {
             return new StoredProcedures(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseFunction> Functions(string name)
         {
             return new Functions(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseArgument> ProcedureArguments(string name)
         {
             return new ProcedureArguments(Owner, name)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<ProcedureSource> ProcedureSources(string name)
         {
             return new ProcedureSources(Owner, null)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseUser> Users()
         {
-            return new Users().Execute(DbConnection);
+            return new Users().Execute(DbConnection, DbTransaction);
         }
 
         public override void PostProcessing(DatabaseTable databaseTable)

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/SqlServerCeAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Adapters/SqlServerCeAdapter.cs
@@ -17,37 +17,37 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Adapters
         public override IList<DatabaseTable> Tables(string tableName)
         {
             return new Tables(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseColumn> Columns(string tableName)
         {
             return new Columns(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseIndex> Indexes(string tableName)
         {
             return new Indexes(Owner, tableName)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> PrimaryKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.PrimaryKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> UniqueKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.UniqueKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
 
         public override IList<DatabaseConstraint> ForeignKeys(string tableName)
         {
             return new Constraints(Owner, tableName, ConstraintType.ForeignKey)
-                .Execute(DbConnection);
+                .Execute(DbConnection, DbTransaction);
         }
     }
 }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/ConnectionContext/ConnectionAdapter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/ConnectionContext/ConnectionAdapter.cs
@@ -16,6 +16,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.ConnectionContext
         }
 #if COREFX
         public DbConnection DbConnection => _parameters.DbConnection;
+
+        public DbTransaction DbTransaction => _parameters.DbTransaction;
+
 #else
 
         public DbConnection DbConnection
@@ -27,6 +30,14 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.ConnectionContext
                     CreateDbConnection();
                 }
                 return _dbConnection;
+            }
+        }
+
+        public DbTransaction DbTransaction
+        {
+            get
+            {
+                return null;
             }
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/CheckConstraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/CheckConstraints.cs
@@ -57,9 +57,9 @@ ORDER BY rel.rdb$relation_name, chk.rdb$constraint_name
             }
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Columns.cs
@@ -58,9 +58,9 @@ ORDER BY rfr.rdb$relation_name, rfr.rdb$field_position
 ";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Constraints.cs
@@ -103,9 +103,9 @@ ORDER BY
             }
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Functions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Functions.cs
@@ -23,9 +23,9 @@ ORDER BY rdb$function_name
 
         }
 
-        public IList<DatabaseFunction> Execute(DbConnection connection)
+        public IList<DatabaseFunction> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Indexes.cs
@@ -69,9 +69,9 @@ WHERE
             index.Columns.Add(col);
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/ProcedureArguments.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/ProcedureArguments.cs
@@ -50,9 +50,9 @@ ORDER BY pp.rdb$procedure_name, pp.rdb$parameter_type, pp.rdb$parameter_number
 
         }
 
-        public IList<DatabaseArgument> Execute(DbConnection connection)
+        public IList<DatabaseArgument> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Sequences.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Sequences.cs
@@ -18,9 +18,9 @@ WHERE RDB$SYSTEM_FLAG=0";
 
         }
 
-        public IList<DatabaseSequence> Execute(DbConnection connection)
+        public IList<DatabaseSequence> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/StoredProcedures.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/StoredProcedures.cs
@@ -26,9 +26,9 @@ ORDER BY rdb$procedure_name
 
         }
 
-        public IList<DatabaseStoredProcedure> Execute(DbConnection connection)
+        public IList<DatabaseStoredProcedure> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Tables.cs
@@ -28,9 +28,9 @@ ORDER BY
 ";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Triggers.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Triggers.cs
@@ -104,9 +104,9 @@ ORDER BY t.rdb$relation_name, t.rdb$trigger_name
             return triggerType;
         }
 
-        public IList<DatabaseTrigger> Execute(DbConnection dbConnection)
+        public IList<DatabaseTrigger> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Users.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Users.cs
@@ -26,9 +26,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.Firebird
             Result.Add(constraint);
         }
 
-        public IList<DatabaseUser> Execute(DbConnection dbConnection)
+        public IList<DatabaseUser> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/ViewColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/ViewColumns.cs
@@ -56,9 +56,9 @@ ORDER BY rel.rdb$relation_name, rfr.rdb$field_position
 ";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Views.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Firebird/Views.cs
@@ -28,9 +28,9 @@ ORDER BY
 ";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Columns.cs
@@ -38,9 +38,9 @@ where
     c.TABLE_SCHEMA, c.TABLE_NAME, ORDINAL_POSITION";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/ComputedColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/ComputedColumns.cs
@@ -27,7 +27,7 @@ GENERATION_EXPRESSION  <> ''
 ORDER BY TABLE_SCHEMA,TABLE_NAME";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
             var hasGeneratedColumns = false; //introduced in MySQL 5.7.6
             var cmd = connection.CreateCommand();
@@ -54,7 +54,7 @@ LIMIT 1";
                 return new List<DatabaseColumn>();
             }
 
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Constraints.cs
@@ -108,9 +108,9 @@ ORDER BY
             constraint.Columns.Add(columnName);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Functions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Functions.cs
@@ -28,9 +28,9 @@ ORDER BY ROUTINE_SCHEMA, ROUTINE_NAME";
 
         }
 
-        public IList<DatabaseFunction> Execute(DbConnection connection)
+        public IList<DatabaseFunction> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/IdentityColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/IdentityColumns.cs
@@ -24,9 +24,9 @@ WHERE EXTRA = 'auto_increment' AND
 (TABLE_SCHEMA = @schemaOwner OR @schemaOwner IS NULL)";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Indexes.cs
@@ -68,9 +68,9 @@ ORDER BY
             index.Columns.Add(col);
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/ProcedureArguments.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/ProcedureArguments.cs
@@ -32,11 +32,11 @@ ORDER BY SPECIFIC_SCHEMA, SPECIFIC_NAME, PARAMETER_NAME";
 
         }
 
-        public IList<DatabaseArgument> Execute(DbConnection connection)
+        public IList<DatabaseArgument> Execute(DbConnection connection, DbTransaction transaction)
         {
             try
             {
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (Exception e)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/StoredProcedures.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/StoredProcedures.cs
@@ -27,9 +27,9 @@ ORDER BY ROUTINE_SCHEMA, ROUTINE_NAME";
 
         }
 
-        public IList<DatabaseStoredProcedure> Execute(DbConnection connection)
+        public IList<DatabaseStoredProcedure> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Tables.cs
@@ -25,9 +25,9 @@ where
     TABLE_SCHEMA, TABLE_NAME";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Triggers.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Triggers.cs
@@ -49,9 +49,9 @@ WHERE
             Result.Add(trigger);
         }
 
-        public IList<DatabaseTrigger> Execute(DbConnection dbConnection)
+        public IList<DatabaseTrigger> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Users.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Users.cs
@@ -26,9 +26,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.MySql
             Result.Add(constraint);
         }
 
-        public IList<DatabaseUser> Execute(DbConnection dbConnection)
+        public IList<DatabaseUser> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/ViewColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/ViewColumns.cs
@@ -34,9 +34,9 @@ where
     c.TABLE_SCHEMA, c.TABLE_NAME, ORDINAL_POSITION";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Views.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/MySql/Views.cs
@@ -22,9 +22,9 @@ where
     TABLE_SCHEMA, TABLE_NAME";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/CheckConstraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/CheckConstraints.cs
@@ -55,9 +55,9 @@ ORDER BY cons.table_name, cons.constraint_name";
             Result.Add(constraint);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ColumnDescriptions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ColumnDescriptions.cs
@@ -27,9 +27,9 @@ WHERE
     COMMENTS IS NOT NULL";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Columns.cs
@@ -33,9 +33,9 @@ AND (TABLE_NAME  = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY OWNER, TABLE_NAME, COLUMN_ID";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ComputedColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ComputedColumns.cs
@@ -26,14 +26,14 @@ VIRTUAL_COLUMN = 'YES' AND
 ORDER BY TABLE_NAME, COLUMN_NAME";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
             if (Version(connection) < 11)
             {
                 //only supported in 11g+
                 return new List<DatabaseColumn>();
             }
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Constraints.cs
@@ -95,9 +95,9 @@ ORDER BY cols.constraint_name,cols.table_name, cols.position";
             constraint.Columns.Add(columnName);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Functions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Functions.cs
@@ -21,11 +21,11 @@ ORDER BY OWNER,OBJECT_NAME";
 
         }
 
-        public IList<DatabaseFunction> Execute(DbConnection connection)
+        public IList<DatabaseFunction> Execute(DbConnection connection, DbTransaction transaction)
         {
             try
             {
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (DbException ex)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/IdentityColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/IdentityColumns.cs
@@ -27,13 +27,13 @@ WHERE
 ORDER BY TABLE_NAME, COLUMN_NAME";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
             if (Version(connection) < 12)
             {
                 return new List<DatabaseColumn>();
             }
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Indexes.cs
@@ -73,9 +73,9 @@ ORDER BY cols.TABLE_OWNER,
 
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/MaterializedViewColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/MaterializedViewColumns.cs
@@ -32,9 +32,9 @@ AND (TABLE_NAME  = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY c.OWNER, TABLE_NAME, COLUMN_ID";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/MaterializedViews.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/MaterializedViews.cs
@@ -22,9 +22,9 @@ WHERE (OWNER = :OWNER OR :OWNER IS NULL)
 AND (MVIEW_NAME = :VIEWNAME OR :VIEWNAME IS NULL)";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Packages.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Packages.cs
@@ -25,9 +25,9 @@ AND OWNER NOT IN ('SYS', 'SYSMAN', 'CTXSYS', 'MDSYS', 'OLAPSYS', 'ORDSYS', 'OUTL
 
         }
 
-        public IList<DatabasePackage> Execute(DbConnection connection)
+        public IList<DatabasePackage> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ProcedureArguments.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ProcedureArguments.cs
@@ -33,9 +33,9 @@ AND (OBJECT_NAME = :PROCEDURENAME OR :PROCEDURENAME IS NULL)
 ORDER BY OWNER, PACKAGE_NAME, OBJECT_NAME, POSITION";
         }
 
-        public IList<DatabaseArgument> Execute(DbConnection connection)
+        public IList<DatabaseArgument> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ProcedureSources.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ProcedureSources.cs
@@ -30,11 +30,11 @@ ORDER BY OWNER, NAME, TYPE, LINE";
 
         }
 
-        public IList<ProcedureSource> Execute(DbConnection connection)
+        public IList<ProcedureSource> Execute(DbConnection connection, DbTransaction transaction)
         {
             try
             {
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (DbException exception)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Sequences.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Sequences.cs
@@ -24,9 +24,9 @@ WHERE
 
         }
 
-        public IList<DatabaseSequence> Execute(DbConnection connection)
+        public IList<DatabaseSequence> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/StoredProcedures.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/StoredProcedures.cs
@@ -28,9 +28,9 @@ AND OWNER NOT IN ('SYS', 'SYSMAN', 'CTXSYS', 'MDSYS', 'OLAPSYS', 'ORDSYS', 'OUTL
 
         }
 
-        public IList<DatabaseStoredProcedure> Execute(DbConnection connection)
+        public IList<DatabaseStoredProcedure> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/TableDescriptions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/TableDescriptions.cs
@@ -25,9 +25,9 @@ WHERE
     COMMENTS IS NOT NULL";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Tables.cs
@@ -24,9 +24,9 @@ WHERE
 ORDER BY OWNER, TABLE_NAME";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Triggers.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Triggers.cs
@@ -49,9 +49,9 @@ TRIGGER_NAME NOT IN ( SELECT object_name FROM USER_RECYCLEBIN )
             Result.Add(trigger);
         }
 
-        public IList<DatabaseTrigger> Execute(DbConnection dbConnection)
+        public IList<DatabaseTrigger> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Users.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Users.cs
@@ -28,9 +28,9 @@ ORDER BY USERNAME";
             Result.Add(constraint);
         }
 
-        public IList<DatabaseUser> Execute(DbConnection dbConnection)
+        public IList<DatabaseUser> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ViewColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ViewColumns.cs
@@ -34,9 +34,9 @@ AND (TABLE_NAME  = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY c.OWNER, TABLE_NAME, COLUMN_ID";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ViewIndexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/ViewIndexes.cs
@@ -75,9 +75,9 @@ ORDER BY cols.TABLE_OWNER,
 
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Views.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/Oracle/Views.cs
@@ -24,9 +24,9 @@ AND OWNER NOT IN ('SYS', 'SYSMAN', 'CTXSYS', 'MDSYS', 'OLAPSYS', 'ORDSYS', 'OUTL
 ";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/CheckConstraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/CheckConstraints.cs
@@ -54,9 +54,9 @@ ORDER BY cons.table_name, cons.constraint_name";
             Result.Add(constraint);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/ColumnDescriptions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/ColumnDescriptions.cs
@@ -32,9 +32,9 @@ WHERE
     (ns.nspname = :schemaOwner OR :schemaOwner IS NULL)";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Columns.cs
@@ -31,9 +31,9 @@ AND (table_name = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY table_schema, table_name, ordinal_position";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Constraints.cs
@@ -106,9 +106,9 @@ ORDER BY
             constraint.Columns.Add(columnName);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Functions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Functions.cs
@@ -31,11 +31,11 @@ INNER JOIN pg_language lng ON lng.oid = pr.prolang
 
         }
 
-        public IList<DatabaseFunction> Execute(DbConnection connection)
+        public IList<DatabaseFunction> Execute(DbConnection connection, DbTransaction transaction)
         {
             try
             {
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (DbException ex)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Indexes.cs
@@ -42,9 +42,9 @@ ORDER BY
     n.nspname, t.relname, i.relname";
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection connection)
+        public IList<DatabaseIndex> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/MaterializedViews.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/MaterializedViews.cs
@@ -38,7 +38,7 @@ AND (matviewname = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY schemaname, matviewname";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
             //or is there something on connection?
             try
@@ -54,7 +54,7 @@ ORDER BY schemaname, matviewname";
                 {
                     Sql = _sql93;
                 }
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (Exception exception)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/ProcedureArguments.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/ProcedureArguments.cs
@@ -44,10 +44,10 @@ INNER JOIN pg_namespace ns ON pr.pronamespace = ns.oid
 
         }
 
-        public IList<DatabaseArgument> Execute(DbConnection connection)
+        public IList<DatabaseArgument> Execute(DbConnection connection, DbTransaction transaction)
         {
             _requiredDataTypes.Clear();
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
 
             //now lookup datatypes
             foreach (var key in _requiredDataTypes.Keys)

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/TableDescriptions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/TableDescriptions.cs
@@ -27,9 +27,9 @@ WHERE
     (ns.nspname = :schemaOwner OR :schemaOwner IS NULL)";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Tables.cs
@@ -22,9 +22,9 @@ AND (table_name = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY table_schema, table_name";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Triggers.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Triggers.cs
@@ -36,7 +36,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.PostgreSql
             Result.Add(trigger);
         }
 
-        public IList<DatabaseTrigger> Execute(DbConnection dbConnection)
+        public IList<DatabaseTrigger> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
             var version = dbConnection.ServerVersion;
             string timing = "CONDITION_TIMING";
@@ -68,7 +68,7 @@ WHERE
 (EVENT_OBJECT_TABLE = :tableName OR :tableName IS NULL) AND 
 (TRIGGER_SCHEMA = :schemaOwner OR :schemaOwner IS NULL)";
 
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Users.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Users.cs
@@ -12,9 +12,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.PostgreSql
             Sql = @"SELECT usename as user_name FROM pg_catalog.pg_user";
         }
 
-        public IList<DatabaseUser> Execute(DbConnection connection)
+        public IList<DatabaseUser> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Views.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/PostgreSql/Views.cs
@@ -23,9 +23,9 @@ AND (table_name = :TABLENAME OR :TABLENAME IS NULL)
 ORDER BY table_schema, table_name";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Columns.cs
@@ -17,9 +17,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SQLite
         protected List<DatabaseColumn> Result { get; } = new List<DatabaseColumn>();
         public string PragmaSql { get; set; }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            var tables = new Tables(_tableName).Execute(connection);
+            var tables = new Tables(_tableName).Execute(connection, transaction);
 
             foreach (var table in tables)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Constraints.cs
@@ -18,9 +18,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SQLite
         protected List<DatabaseConstraint> Result { get; } = new List<DatabaseConstraint>();
         public string PragmaSql { get; set; }
 
-        public IList<DatabaseConstraint> Execute(DbConnection connection)
+        public IList<DatabaseConstraint> Execute(DbConnection connection, DbTransaction transaction)
         {
-            var tables = new Tables(_tableName).Execute(connection);
+            var tables = new Tables(_tableName).Execute(connection, transaction);
 
             foreach (var table in tables)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Indexes.cs
@@ -49,9 +49,9 @@ ORDER BY tbl_name, name";
             }
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
 
             foreach (var index in Result)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Tables.cs
@@ -18,9 +18,9 @@ WHERE type='table' AND
 ORDER BY name";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Triggers.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Triggers.cs
@@ -37,9 +37,9 @@ ORDER BY tbl_name, name";
             Result.Add(trigger);
         }
 
-        public IList<DatabaseTrigger> Execute(DbConnection dbConnection)
+        public IList<DatabaseTrigger> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/ViewColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/ViewColumns.cs
@@ -17,9 +17,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SQLite
         protected List<DatabaseColumn> Result { get; } = new List<DatabaseColumn>();
         public string PragmaSql { get; set; }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            var views = new Views(_viewName).Execute(connection);
+            var views = new Views(_viewName).Execute(connection, transaction);
 
             foreach (var view in views)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Views.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SQLite/Views.cs
@@ -18,9 +18,9 @@ WHERE type='view' AND
 ORDER BY name";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlExecuter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlExecuter.cs
@@ -11,7 +11,6 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases
     {
 
         protected List<T> Result { get; } = new List<T>();
-        
     }
 
     abstract class SqlExecuter

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlExecuter.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlExecuter.cs
@@ -11,7 +11,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases
     {
 
         protected List<T> Result { get; } = new List<T>();
-
+        
     }
 
     abstract class SqlExecuter
@@ -21,7 +21,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases
 
         public string Owner { get; set; }
 
-        protected void ExecuteDbReader(DbConnection connection)
+        protected void ExecuteDbReader(DbConnection connection, DbTransaction transaction)
         {
             if (connection.State == ConnectionState.Closed)
             {
@@ -30,6 +30,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases
             Trace.WriteLine($"Sql: {Sql}");
             using (var cmd = connection.CreateCommand())
             {
+                cmd.Transaction = transaction;
                 cmd.CommandText = Sql;
                 AddParameters(cmd);
                 using (var dr = cmd.ExecuteReader())
@@ -40,6 +41,16 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases
                     }
                 }
             }
+        }
+
+        protected DbCommand BuildCommand(DbConnection connection, DbTransaction transaction)
+        {
+            var cmd =  connection.CreateCommand();
+            if (transaction != null)
+            {
+                cmd.Transaction = transaction;
+            }
+            return cmd;
         }
 
         protected static DbParameter AddDbParameter(DbCommand command, string parameterName, object value, DbType? dbType = null)

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/CheckConstraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/CheckConstraints.cs
@@ -55,9 +55,9 @@ ORDER BY cons.table_name, cons.constraint_name";
             Result.Add(constraint);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ColumnDescriptions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ColumnDescriptions.cs
@@ -35,9 +35,9 @@ o.type= 'U'
 ORDER BY s.name, o.name";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Columns.cs
@@ -38,9 +38,9 @@ where
     c.TABLE_SCHEMA, c.TABLE_NAME, ORDINAL_POSITION";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ComputedColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ComputedColumns.cs
@@ -28,9 +28,9 @@ o.type= 'U'
 ORDER BY o.name, c.name";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Constraints.cs
@@ -106,9 +106,9 @@ ORDER BY
             constraint.Columns.Add(columnName);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/DefaultConstraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/DefaultConstraints.cs
@@ -68,9 +68,9 @@ ORDER BY s.name, o.name";
             constraint.Columns.Add(columnName);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Functions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Functions.cs
@@ -37,9 +37,9 @@ ORDER BY SPECIFIC_SCHEMA, SPECIFIC_NAME";
 
         }
 
-        public IList<DatabaseFunction> Execute(DbConnection connection)
+        public IList<DatabaseFunction> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/IdentityColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/IdentityColumns.cs
@@ -29,9 +29,9 @@ o.type= 'U'
 ORDER BY o.name, c.name";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Indexes.cs
@@ -82,9 +82,9 @@ ORDER BY
 
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ProcedureArguments.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ProcedureArguments.cs
@@ -47,9 +47,9 @@ ORDER BY SPECIFIC_SCHEMA, SPECIFIC_NAME, PARAMETER_NAME";
 
         }
 
-        public IList<DatabaseArgument> Execute(DbConnection connection)
+        public IList<DatabaseArgument> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ProcedureSources.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ProcedureSources.cs
@@ -28,11 +28,11 @@ WHERE (o.type = N'P' OR o.type = N'FN' OR o.type = N'TF' OR o.type='PC' OR o.typ
 ORDER BY o.type;";
         }
 
-        public IList<ProcedureSource> Execute(DbConnection connection)
+        public IList<ProcedureSource> Execute(DbConnection connection, DbTransaction transaction)
         {
             try
             {
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (DbException exception)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Sequences.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Sequences.cs
@@ -23,9 +23,9 @@ WHERE
 
         }
 
-        public IList<DatabaseSequence> Execute(DbConnection connection)
+        public IList<DatabaseSequence> Execute(DbConnection connection, DbTransaction transaction)
         {
-            var cmd = connection.CreateCommand();
+            var cmd = BuildCommand(connection, transaction);
             //step 1- check if there are any sequences (backwards compatible)
             cmd.CommandText = @"SELECT COUNT(*) 
 FROM sys.objects 
@@ -40,7 +40,7 @@ WHERE type= 'SO' AND
             //step 2- they have them
             //we can use the SqlServer 2012 sys.sequences catalog view
             //renamed for compatibility with Oracle's ALL_SEQUENCES
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/StoredProcedures.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/StoredProcedures.cs
@@ -37,9 +37,9 @@ ORDER BY SPECIFIC_SCHEMA, SPECIFIC_NAME";
 
         }
 
-        public IList<DatabaseStoredProcedure> Execute(DbConnection connection)
+        public IList<DatabaseStoredProcedure> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/TableDescriptions.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/TableDescriptions.cs
@@ -31,9 +31,9 @@ WHERE
 ORDER BY s.name, o.name";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Tables.cs
@@ -23,9 +23,9 @@ where
     TABLE_SCHEMA, TABLE_NAME";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Triggers.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Triggers.cs
@@ -74,9 +74,9 @@ WHERE (SCHEMA_NAME(parent.schema_id) = @Owner or (@Owner is null))
             Result.Add(trigger);
         }
 
-        public IList<DatabaseTrigger> Execute(DbConnection dbConnection)
+        public IList<DatabaseTrigger> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Users.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Users.cs
@@ -26,9 +26,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SqlServer
             Result.Add(constraint);
         }
 
-        public IList<DatabaseUser> Execute(DbConnection dbConnection)
+        public IList<DatabaseUser> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ViewColumns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ViewColumns.cs
@@ -35,9 +35,9 @@ where
     c.TABLE_SCHEMA, c.TABLE_NAME, ORDINAL_POSITION";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ViewIndexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ViewIndexes.cs
@@ -80,9 +80,9 @@ ORDER BY
 
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ViewSources.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ViewSources.cs
@@ -28,11 +28,11 @@ WHERE (o.type='V')
 ORDER BY o.type;";
         }
 
-        public IList<ProcedureSource> Execute(DbConnection connection)
+        public IList<ProcedureSource> Execute(DbConnection connection, DbTransaction transaction)
         {
             try
             {
-                ExecuteDbReader(connection);
+                ExecuteDbReader(connection, transaction);
             }
             catch (DbException exception)
             {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Views.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Views.cs
@@ -22,9 +22,9 @@ where
     TABLE_SCHEMA, TABLE_NAME";
         }
 
-        public IList<DatabaseView> Execute(DbConnection connection)
+        public IList<DatabaseView> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Columns.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Columns.cs
@@ -35,9 +35,9 @@ where
     TABLE_SCHEMA, TABLE_NAME, ORDINAL_POSITION";
         }
 
-        public IList<DatabaseColumn> Execute(DbConnection connection)
+        public IList<DatabaseColumn> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Constraints.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Constraints.cs
@@ -89,9 +89,9 @@ ORDER BY
             constraint.Columns.Add(columnName);
         }
 
-        public IList<DatabaseConstraint> Execute(DbConnection dbConnection)
+        public IList<DatabaseConstraint> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Indexes.cs
@@ -72,9 +72,9 @@ ORDER BY
 
         }
 
-        public IList<DatabaseIndex> Execute(DbConnection dbConnection)
+        public IList<DatabaseIndex> Execute(DbConnection dbConnection, DbTransaction transaction)
         {
-            ExecuteDbReader(dbConnection);
+            ExecuteDbReader(dbConnection, transaction);
             return Result;
         }
     }

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Tables.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/Tables.cs
@@ -23,9 +23,9 @@ where
     TABLE_SCHEMA, TABLE_NAME";
         }
 
-        public IList<DatabaseTable> Execute(DbConnection connection)
+        public IList<DatabaseTable> Execute(DbConnection connection, DbTransaction transaction)
         {
-            ExecuteDbReader(connection);
+            ExecuteDbReader(connection, transaction);
             return Result;
         }
 

--- a/DatabaseSchemaReader/ProviderSchemaReaders/SchemaParameters.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/SchemaParameters.cs
@@ -21,10 +21,10 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders
         {
             DbTransaction = dbTransaction;
         }
+        
+        public System.Data.Common.DbConnection DbConnection { get; private set; }
 
         public System.Data.Common.DbTransaction DbTransaction { get; private set; }
-
-        public System.Data.Common.DbConnection DbConnection { get; private set; }
 #else
         public SchemaParameters(string connectionString, SqlType sqlType)
         {

--- a/DatabaseSchemaReader/ProviderSchemaReaders/SchemaParameters.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/SchemaParameters.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Data.Common;
 using DatabaseSchemaReader.DataSchema;
 using DatabaseSchemaReader.Filters;
 
@@ -15,6 +16,13 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders
             SqlType = ProviderToSqlType.Convert(ProviderName);
             Exclusions = new Exclusions();
         }
+
+        public SchemaParameters(System.Data.Common.DbTransaction dbTransaction) :this(dbTransaction.Connection)
+        {
+            DbTransaction = dbTransaction;
+        }
+
+        public System.Data.Common.DbTransaction DbTransaction { get; private set; }
 
         public System.Data.Common.DbConnection DbConnection { get; private set; }
 #else

--- a/DatabaseSchemaReader/project.json
+++ b/DatabaseSchemaReader/project.json
@@ -3,7 +3,7 @@
         "summary": "A simple, cross-database tool to read database metadata",
         "tags": [ "ADO", "Entity Framework Code First", "SQLServer", "SQLite", "Oracle", "MySQL", "PostgreSql", "Schema", "Database" ],
         "owners": [ "Martin Willey" ],
-        "releaseNotes": "2.3.0: Add Firebird support in .net Core; fix for Codegen",
+        "releaseNotes": "2.3.1: Added transaction support so connections with a local pending transaction can be used.",
         "projectUrl": "https://github.com/martinjw/dbschemareader",
         "licenseUrl": "http://www.microsoft.com/en-us/openness/licenses.aspx#MPL",
         "repository": {
@@ -11,7 +11,7 @@
             "url": "https://github.com/martinjw/dbschemareader"
         }
     },
-    "version": "2.3.0-*",
+    "version": "2.3.1-*",
     "authors": [ "Martin Willey" ],
     "description": "Any ADO provider can be read  (SqlServer, SqlServer CE 4, MySQL, SQLite, System.Data.OracleClient, ODP, Devart, PostgreSql, DB2...) into a single standard model.",
     "title": "DatabaseSchemaReader",


### PR DESCRIPTION
I have modified the DatabaseReader so it can be instantiated using a DbTransaction.  This is to allow for the scenario where a connection is to be reused that has an uncommitted transaction.

This change is for SQL Server databases, using the .Net Core framework.  