### PR TITLE
Changed mapping of tinyint from System.SByte to System.Byte

### DIFF
--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/DataTypes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/DataTypes.cs
@@ -43,7 +43,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SqlServer
                 ProviderDbType = 2,
                 CreateFormat = "bit",
             });
-            dts.Add(new DataType("tinyint", "System.SByte")
+            dts.Add(new DataType("tinyint", "System.Byte")
             {
                 ProviderDbType = 20,
                 CreateFormat = "tinyint",

--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/DataTypeList.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServerCe/DataTypeList.cs
@@ -39,7 +39,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SqlServerCe
                 ProviderDbType = 11,
                 CreateFormat = "bit",
             });
-            dts.Add(new DataType("tinyint", "System.SByte")
+            dts.Add(new DataType("tinyint", "System.Byte")
             {
                 ProviderDbType = 17,
                 CreateFormat = "tinyint",


### PR DESCRIPTION
I changed mapping of tinyint from System.SByte to System.Byte according to MSDN documentation

Links to MSDN articles:
[SQL Server Data Types and Their .NET Framework Equivalents](https://msdn.microsoft.com/en-us/library/ms131092%28SQL.90%29.aspx?f=255&MSPPError=-2147217396)
[Managed Data Type Mappings (SQL Server Compact)](https://technet.microsoft.com/en-us/library/ms174642%28v=sql.110%29.aspx?f=255&MSPPError=-2147217396)
