### PR TITLE
Load DbProviderFactory from external assembly with AssemblyLoader

### DIFF
--- a/DatabaseSchemaReader/DatabaseSchemaReader.csproj
+++ b/DatabaseSchemaReader/DatabaseSchemaReader.csproj
@@ -52,8 +52,12 @@
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' Or '$(TargetFramework)' == 'net45' ">
+    <DefineConstants>TRACE;DEBUG;NET4</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' Or '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);COREFX</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;COREFX;NETSTANDARD2_0;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/DatabaseSchemaReader/Utilities/DbProvider/AssemblyHelper.cs
+++ b/DatabaseSchemaReader/Utilities/DbProvider/AssemblyHelper.cs
@@ -16,26 +16,27 @@ namespace DatabaseSchemaReader.Utilities
         /// <returns></returns>
         public static Type LoadTypeFrom(string assemblyQualifiedName)
         {
-            // This will return null
-            // Just here to test that the simple GetType overload can't return the actual type
-            var t0 = Type.GetType(assemblyQualifiedName);
+            // load type from assembly
+            var type = Type.GetType(assemblyQualifiedName);
 
-			#if NET4
-            // Throws exception is type was not found
-            return Type.GetType(
-                assemblyQualifiedName,
-                name =>
-                {
-                    // Returns the assembly of the type by enumerating loaded assemblies
-                    // in the app domain            
-                    return AppDomain.CurrentDomain.GetAssemblies().Where(z => z.FullName == name.FullName)
-                        .FirstOrDefault();
-                },
-                null,
-                true);
-            #else
-            return t0;
-            #endif
+#if NET4
+            if (type == null)
+            {
+                // load type from assembly with custom assembly resolver
+                type = Type.GetType(
+                    assemblyQualifiedName,
+                    name =>
+                    {
+                        // Returns the assembly of the type by enumerating loaded assemblies
+                        // in the app domain            
+                        return AppDomain.CurrentDomain.GetAssemblies().Where(z => z.FullName == name.FullName)
+                            .FirstOrDefault();
+                    },
+                    null,
+                    false);  
+            }
+#endif
+            return type;
         }
     }
 }

--- a/DatabaseSchemaReader/Utilities/DbProvider/AssemblyHelper.cs
+++ b/DatabaseSchemaReader/Utilities/DbProvider/AssemblyHelper.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Linq;
+
+namespace DatabaseSchemaReader.Utilities
+{
+    /// <summary>
+    ///     Helper class for assembly access.
+    /// </summary>
+    public static class AssemblyHelper
+    {
+        /// <summary>
+        ///     Loads the type from an assembly qualified name. This allows loading types also if there are loaded dynamically
+        ///     before by Assembly.LoadFile method.
+        /// </summary>
+        /// <param name="assemblyQualifiedName">Name of the assembly qualified.</param>
+        /// <returns></returns>
+        public static Type LoadTypeFrom(string assemblyQualifiedName)
+        {
+            // This will return null
+            // Just here to test that the simple GetType overload can't return the actual type
+            var t0 = Type.GetType(assemblyQualifiedName);
+
+			#if NET4
+            // Throws exception is type was not found
+            return Type.GetType(
+                assemblyQualifiedName,
+                name =>
+                {
+                    // Returns the assembly of the type by enumerating loaded assemblies
+                    // in the app domain            
+                    return AppDomain.CurrentDomain.GetAssemblies().Where(z => z.FullName == name.FullName)
+                        .FirstOrDefault();
+                },
+                null,
+                true);
+            #else
+            return t0;
+            #endif
+        }
+    }
+}

--- a/DatabaseSchemaReader/Utilities/DbProvider/DbProviderFactoryRepository.cs
+++ b/DatabaseSchemaReader/Utilities/DbProvider/DbProviderFactoryRepository.cs
@@ -57,8 +57,7 @@ namespace DatabaseSchemaReader.Utilities.DbProvider
         /// <returns></returns>
         public DbProviderFactory GetFactory(DbProviderFactoryDescription description)
         {
-            var providerType = //AssemblyHelper.LoadTypeFrom(description.AssemblyQualifiedName);
-                Type.GetType(description.AssemblyQualifiedName);
+            var providerType = AssemblyHelper.LoadTypeFrom(description.AssemblyQualifiedName);
             if (providerType == null) return null;
 
             var providerInstance = providerType.GetField("Instance",


### PR DESCRIPTION
Currently loading external DbProviderFactory in GetFactory() implementation is based on Type.GetType(...). this will fail (in my case) everytime returning null. This can also be reproduced trying Type.GetType() directly after AppDomain.CurrentDomain.Load(...) which will return everytime null.

My implementation uses a simple AssemblyLoader as static helper class. It uses Type.GetType overloading with AssemblyResolver function. NOTE: This is only possible in .NET 4+. Therefore a new build constant was necessary.

EDIT: I see test case TestRepository has failed because of FileNotFoundException of direct referenced System.Data.SQlite. In my case the assemblies aren't referenced directly. Perhaps turning throwOnError to false of GetType could solve this.

EDIT2: I've tested locally with a direct referenced db provider which works in my case without throwing a FileNotFoundException or so on.