### PR TITLE
TableName set to actual table name from DB collection

### DIFF
--- a/DatabaseSchemaReader/ProviderSchemaReaders/Builders/TableBuilder.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Builders/TableBuilder.cs
@@ -47,6 +47,9 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Builders
             {
                 return null;
             }
+
+            tableName = tables.FirstOrDefault()?.Name ?? tableName;
+
             if (string.IsNullOrEmpty(_readerAdapter.Parameters.Owner))
             {
                 var owner = tables[0].SchemaOwner;


### PR DESCRIPTION
There is a bug in current implementation for example when searching for a specific table using DatabaseReader.Table method. Even though the method finds and returns the table schema, the  indexes are not applied if we use a different case sensitivity for the table name. 

The real issue is inside UpdateIndexes method of TableBuilder class, the line below doesn't find the table because the equality check is case-sensitive:
var tableIndexes = indexes.Where(x => x.SchemaOwner == table.SchemaOwner &&
                                                x.TableName == table.Name);

In order to bypass this, I fixed the tableName property inside Execute method of TableBuilder.