### PR TITLE
Fixed Index columns ordering (only for SqlServer db type)

### DIFF
--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Indexes.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/Indexes.cs
@@ -38,7 +38,7 @@ WHERE
 	 t.is_ms_shipped = 0 AND
      ic.is_included_column = 0
 ORDER BY 
-     t.name, ind.name, ic.index_column_id";
+     t.name, ind.name, ic.key_ordinal";
 
         }
 


### PR DESCRIPTION
For SqlServer database type, when loading the indexes, the order of the columns that appear in the index was not the correct one. Fixed the sql query on /SqlServer/Indexes.cs class, by ordering by key_ordinal and not column_id.

Here you can see details sys.index_columns.key_ordinal versus index_column_id: 

https://social.msdn.microsoft.com/Forums/sqlserver/en-US/8b86747a-d37a-4a51-b373-89cf4eaac02b/sysindexcolumnskeyordinal-versus-indexcolumnid?forum=sqldatabaseengine

