### PR TITLE
#78 mssql clusteredindex

### DIFF
--- a/DatabaseSchemaReader/DatabaseSchemaReader.csproj
+++ b/DatabaseSchemaReader/DatabaseSchemaReader.csproj
@@ -10,7 +10,8 @@
     <AssemblyName>DatabaseSchemaReader</AssemblyName>
     <PackageId>DatabaseSchemaReader</PackageId>
     <PackageTags>ADO;Entity Framework Code First;SQLServer;SQLite;Oracle;MySQL;PostgreSql;Schema;Database</PackageTags>
-    <PackageReleaseNotes>2.6.0: #68 IndexConverter.FindBoolean, #66 column list</PackageReleaseNotes>
+    <PackageReleaseNotes>2.6.0: #68 IndexConverter.FindBoolean, #66 column list
+2.6.1: #78 SqlServerMigrator supports CLUSTERED indices</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/martinjw/dbschemareader</PackageProjectUrl>
     <PackageLicenseUrl>http://www.microsoft.com/en-us/openness/licenses.aspx#MPL</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
@@ -24,7 +25,7 @@
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>2.6.0</Version>
+    <Version>2.6.1</Version>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">

--- a/DatabaseSchemaReader/SqlGen/MigrationGenerator.cs
+++ b/DatabaseSchemaReader/SqlGen/MigrationGenerator.cs
@@ -534,7 +534,7 @@ namespace DatabaseSchemaReader.SqlGen
             return string.Empty;
         }
 
-        private string GetColumnList(IEnumerable<string> columns)
+        protected string GetColumnList(IEnumerable<string> columns)
         {
             var escapedColumnNames = columns.Select(column => Escape(column)).ToArray();
             return string.Join(", ", escapedColumnNames);

--- a/DatabaseSchemaReader/SqlGen/SqlServer/SqlServerMigrationGenerator.cs
+++ b/DatabaseSchemaReader/SqlGen/SqlServer/SqlServerMigrationGenerator.cs
@@ -142,7 +142,7 @@ namespace DatabaseSchemaReader.SqlGen.SqlServer
             //we could plug in "CLUSTERED" or "PRIMARY XML" from index.IndexType here
             var indexType = index.IsUnique ? "UNIQUE " : string.Empty;
 
-            var clustered = string.IsNullOrWhiteSpace(index.IndexType) ? string.Empty : index.IndexType + " ";
+            var clustered = string.IsNullOrEmpty(index.IndexType?.Trim()) ? string.Empty : index.IndexType + " ";
 
             return string.Format(CultureInfo.InvariantCulture,
                        "CREATE {0}{4}INDEX {1} ON {2}({3})",

--- a/DatabaseSchemaReader/SqlGen/SqlServer/SqlServerMigrationGenerator.cs
+++ b/DatabaseSchemaReader/SqlGen/SqlServer/SqlServerMigrationGenerator.cs
@@ -131,5 +131,26 @@ namespace DatabaseSchemaReader.SqlGen.SqlServer
                 Escape(index.Name),
                 TableName(databaseTable));
         }
+
+        public override string AddIndex(DatabaseTable databaseTable, DatabaseIndex index)
+        {
+            if (index.Columns.Count == 0)
+            {
+                //IndexColumns errors 
+                return "-- add index " + index.Name + " (unknown columns)";
+            }
+            //we could plug in "CLUSTERED" or "PRIMARY XML" from index.IndexType here
+            var indexType = index.IsUnique ? "UNIQUE " : string.Empty;
+
+            var clustered = string.IsNullOrWhiteSpace(index.IndexType) ? string.Empty : index.IndexType + " ";
+
+            return string.Format(CultureInfo.InvariantCulture,
+                       "CREATE {0}{4}INDEX {1} ON {2}({3})",
+                       indexType, //must have trailing space
+                       Escape(index.Name),
+                       TableName(databaseTable),
+                       GetColumnList(index.Columns.Select(i => i.Name)),
+                       clustered) + LineEnding();
+        }
     }
 }

--- a/DatabaseSchemaReaderTest/SqlGen/Migrations/UnitTests/MigrationAddIndex.cs
+++ b/DatabaseSchemaReaderTest/SqlGen/Migrations/UnitTests/MigrationAddIndex.cs
@@ -12,7 +12,6 @@ namespace DatabaseSchemaReaderTest.SqlGen.Migrations.UnitTests
         [TestMethod]
         public void TestSqlServerWithSchema()
         {
-
             //arrange
             var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
 
@@ -31,7 +30,6 @@ namespace DatabaseSchemaReaderTest.SqlGen.Migrations.UnitTests
         [TestMethod]
         public void TestSqlServerNonUnique()
         {
-
             //arrange
             var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
 
@@ -49,9 +47,50 @@ namespace DatabaseSchemaReaderTest.SqlGen.Migrations.UnitTests
         }
 
         [TestMethod]
+        public void TestSqlServerNonUnique_NonClustered()
+        {
+            //arrange
+            var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
+
+            var table = MigrationCommon.CreateTestTable("Orders");
+            table.SchemaOwner = "dbo";
+            var column = MigrationCommon.CreateNewColumn();
+            var index = MigrationCommon.CreateUniqueIndex(column, "COUNTRY");
+            index.IsUnique = false;
+            index.IndexType = "NONCLUSTERED";
+
+            //act
+            var sql = migration.AddIndex(table, index);
+
+            //assert
+            Assert.IsTrue(sql.StartsWith("CREATE NONCLUSTERED INDEX [UI_COUNTRY] ON [dbo].[Orders]([COUNTRY])", StringComparison.OrdinalIgnoreCase), "names should be quoted correctly");
+        }
+
+
+        [TestMethod]
+        public void TestSqlServerNonUnique_Clustered()
+        {
+            //arrange
+            var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
+
+            var table = MigrationCommon.CreateTestTable("Orders");
+            table.SchemaOwner = "dbo";
+            var column = MigrationCommon.CreateNewColumn();
+            var index = MigrationCommon.CreateUniqueIndex(column, "COUNTRY");
+            index.IsUnique = false;
+            index.IndexType = "CLUSTERED";
+
+            //act
+            var sql = migration.AddIndex(table, index);
+
+            //assert
+            Assert.IsTrue(sql.StartsWith("CREATE CLUSTERED INDEX [UI_COUNTRY] ON [dbo].[Orders]([COUNTRY])", StringComparison.OrdinalIgnoreCase), "names should be quoted correctly");
+        }
+
+
+        [TestMethod]
         public void TestSqlServerNoSchema()
         {
-
             //arrange
             var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
 
@@ -66,6 +105,46 @@ namespace DatabaseSchemaReaderTest.SqlGen.Migrations.UnitTests
 
             //assert
             Assert.IsTrue(sql.StartsWith("CREATE UNIQUE INDEX [UI_COUNTRY] ON [Orders]([COUNTRY])", StringComparison.OrdinalIgnoreCase), "names should be quoted correctly");
+        }
+
+        [TestMethod]
+        public void TestSqlServerNoSchema_NonClustered()
+        {
+            //arrange
+            var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
+
+            var table = MigrationCommon.CreateTestTable("Orders");
+            table.SchemaOwner = "dbo";
+            var column = MigrationCommon.CreateNewColumn();
+            var index = MigrationCommon.CreateUniqueIndex(column, "COUNTRY");
+            index.IndexType = "NONCLUSTERED";
+
+            //act
+            migration.IncludeSchema = false;
+            var sql = migration.AddIndex(table, index);
+
+            //assert
+            Assert.IsTrue(sql.StartsWith("CREATE UNIQUE NONCLUSTERED INDEX [UI_COUNTRY] ON [Orders]([COUNTRY])", StringComparison.OrdinalIgnoreCase), "names should be quoted correctly");
+        }
+
+        [TestMethod]
+        public void TestSqlServerNoSchema_Clustered()
+        {
+            //arrange
+            var migration = new DdlGeneratorFactory(SqlType.SqlServer).MigrationGenerator();
+
+            var table = MigrationCommon.CreateTestTable("Orders");
+            table.SchemaOwner = "dbo";
+            var column = MigrationCommon.CreateNewColumn();
+            var index = MigrationCommon.CreateUniqueIndex(column, "COUNTRY");
+            index.IndexType = "CLUSTERED";
+
+            //act
+            migration.IncludeSchema = false;
+            var sql = migration.AddIndex(table, index);
+
+            //assert
+            Assert.IsTrue(sql.StartsWith("CREATE UNIQUE CLUSTERED INDEX [UI_COUNTRY] ON [Orders]([COUNTRY])", StringComparison.OrdinalIgnoreCase), "names should be quoted correctly");
         }
 
 


### PR DESCRIPTION
PR for #78 

Creates a nonclustered index by default.
Creates a CLUSTERED index, if IndexType is set to "CLUSTERED" (just uses the IndexType value, basically)

This also works when comparing tables and their indices, as the framework already extracts the information, whether it is a clustered or nonclustered index. (i.e. it fills IndexType with "CLUSTERED" or "NONCLUSTERED")

Also added unit tests. I hope you are content.