### PR TITLE
SQL Server: Retrieves SQL for inline table-values functions.

### DIFF
--- a/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ProcedureSources.cs
+++ b/DatabaseSchemaReader/ProviderSchemaReaders/Databases/SqlServer/ProcedureSources.cs
@@ -23,7 +23,7 @@ namespace DatabaseSchemaReader.ProviderSchemaReaders.Databases.SqlServer
 FROM sys.sql_modules AS sm
     JOIN sys.objects AS o
         ON sm.object_id = o.object_id
-WHERE (o.type = N'P' OR o.type = N'FN' OR o.type = N'TF' OR o.type='PC' OR o.type='V')
+WHERE (o.type = N'P' OR o.type = N'FN' OR o.type = N'TF' OR o.type = N'IF' OR o.type='PC' OR o.type='V')
     AND (OBJECT_SCHEMA_NAME(o.object_id) = @schemaOwner OR @schemaOwner IS NULL)
     AND (OBJECT_NAME(sm.object_id) = @name OR @name IS NULL)
 ORDER BY o.type;";
@@ -62,10 +62,12 @@ ORDER BY o.type;";
             switch (type)
             {
                 case "P": //sql server procedure
+                case "PC": //sql server assembly procedure
                     source.SourceType = SourceType.StoredProcedure;
                     break;
 
                 case "TF": //sql server table-valued function
+                case "IF": //sql server inline table-valued function
                 case "FN": //sql server scalar function
                     source.SourceType = SourceType.Function;
                     break;


### PR DESCRIPTION
SQL Server change:
Adds 'IF' sys.object type for retrieving and mapping SQL.

Note: I did notice that the 'PC' type was also retrieved from DB but not mapped to stored procedures. Let me know if you want that extra case on line 65 or whether the 'PC' type should be removed from DB query.