### PR TITLE
Foreign key to unique index fix.

### DIFF
--- a/DatabaseSchemaReader/DataSchema/DatabaseSchemaFixer.cs
+++ b/DatabaseSchemaReader/DataSchema/DatabaseSchemaFixer.cs
@@ -33,7 +33,7 @@ namespace DatabaseSchemaReader.DataSchema
                     if (c.ForeignKeyTableNames.Count == 0) return;
                     foreach (var fkTableName in c.ForeignKeyTableNames)
                     {
-                        DatabaseTable fkTable = databaseSchema.FindTableByName(fkTableName);
+                        DatabaseTable fkTable = databaseSchema.FindTableByName(fkTableName, c.SchemaOwner);
                         if (fkTable == null) continue;
                         c.ForeignKeyTable = fkTable;
                         if (!fkTable.ForeignKeyChildren.Contains(table))

--- a/DatabaseSchemaReader/DatabaseReader.cs
+++ b/DatabaseSchemaReader/DatabaseReader.cs
@@ -188,6 +188,9 @@ namespace DatabaseSchemaReader
                 AllUsers();
 
                 if (ct.IsCancellationRequested) return _db;
+                AllSchemas();
+
+                if (ct.IsCancellationRequested) return _db;
                 AllTables(ct);
 
                 if (ct.IsCancellationRequested) return _db;


### PR DESCRIPTION
If the foreign key was pointing to a unique index it wouldn't have the foreign key table and schema updated and the indexes column list would be missing.

Also, FindTableByName call was missing Schema.

